### PR TITLE
Allow git dependencies to be matched against

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -130,7 +130,7 @@ function getMatches() {
       pack.optionalDependencies), function(range, name) {
       if (devPackages[name]) {
         var devVersions = _.filter(_.keys(devPackages[name]), function(version) {
-          return range.startsWith("git+") || semver.satisfies(version, range);
+          return range.startsWith("git+") || range.startsWith("git://") || semver.satisfies(version, range);
         });
 
         if (devVersions.length) {

--- a/src/index.js
+++ b/src/index.js
@@ -130,7 +130,7 @@ function getMatches() {
       pack.optionalDependencies), function(range, name) {
       if (devPackages[name]) {
         var devVersions = _.filter(_.keys(devPackages[name]), function(version) {
-          return semver.satisfies(version, range);
+          return range.startsWith("git+") || semver.satisfies(version, range);
         });
 
         if (devVersions.length) {


### PR DESCRIPTION
This project looks awesome, however it wasn't working with some git based npm dependencies. This fix allows git based dependencies to be matched against. 

It doesn't do anything fancy, any dependency that has a range beginning with "git+" is matched.
