### PR TITLE
make it windows compatible

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -204,7 +204,7 @@ function linkModule(match) {
     })
     //Create symlink
     .then(function() {
-      return fs.symlinkAsync(sourcePath, targetPath);
+      return fs.symlinkAsync(sourcePath, targetPath, 'junction');
     })
     .then(function() {
       if (match.bin) {


### PR DESCRIPTION
symlink creation under windows requires the junktion 'type' parameter to work properly. See: https://nodejs.org/api/fs.html#fs_fs_symlink_target_path_type_callback